### PR TITLE
Html formatting

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,22 +1,23 @@
+
 <!DOCTYPE HTML>
 <!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/404.html -->
 <!-- https://gosoccerboy5.github.io/404 -->
 <html>
     <head>
-        <base href = "https://gosoccerboy5.github.io" />
+        <base href="https://gosoccerboy5.github.io" />
         <title>404 - gosoccerboy5</title>
     </head>
     <body>
         <h1>404</h1>
         <h2>Uh oh, we couldn't find what you looked for.</h2>
         <br>
-        <a href = "/">Return to the homepage?</a>
+        <a href="/">Return to the homepage?</a>
         <br>
-        <a href = "#" id = "goback">Return back to where you were?</a>
+        <a href="#" id="goback">Return back to where you were?</a>
         <br>
         <br>
-        <a href = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"><span class = "small">What's a 404 error?</span></a>
-        <script src = "resources/index.js" onload="reference('/');"></script> 
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"><span class="small">What's a 404 error?</span></a>
+        <script src="resources/index.js" onload="reference('/');"></script> 
         <script>
             document.querySelector("#goback").addEventListener("click", function(event) {
                 event.preventDefault();

--- a/about.html
+++ b/about.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE HTML>
 <!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/about.html -->
 <html>
@@ -14,7 +15,7 @@
         <p>Hello. I'm gosoccerboy5. You can call me, well, gosoccerboy5 (unless you know my real name, which would be creepy).
         </p>
         <p>
-        I started my coding journey in 2015, on a website you may know, called <a href = "https://scratch.mit.edu">Scratch</a>. Back then, I was little. It was really my <a href = "https://scratch.mit.edu/users/collinrocket/">brother</a> who introduced me to Scratch and thus coding.
+        I started my coding journey in 2015, on a website you may know, called <a href="https://scratch.mit.edu">Scratch</a>. Back then, I was little. It was really my <a href="https://scratch.mit.edu/users/collinrocket/">brother</a> who introduced me to Scratch and thus coding.
         </p><p>
         I loved Scratch a whole lot, and I played a lot with it, along with my friends. However, I didn't really get into coding until around 5 years on Scratch, where I decided to get off my butt and try new things. I already had a Khan Academy account, so I started taking Khan Academy's Javascript/processing.js courses. It was the best choice of my <s>life</s> CS career up until then.
         </p><p>
@@ -26,7 +27,7 @@
         <p>
         <small>Written by me, gosoccerboy5, on April 22, 2021.</small>
         </p>
-        <script src = "resources/index.js" onload="reference('./');"></script>
+        <script src="resources/index.js" onload="reference('./');"></script>
     </body>
 </html>
     

--- a/index.html
+++ b/index.html
@@ -1,28 +1,19 @@
 
 <!DOCTYPE HTML>
-<!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/404.html -->
-<!-- https://gosoccerboy5.github.io/404 -->
+<!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/index.html -->
 <html>
     <head>
-        <base href="https://gosoccerboy5.github.io" />
-        <title>404 - gosoccerboy5</title>
+        <title>My Github page</title>
     </head>
     <body>
-        <h1>404</h1>
-        <h2>Uh oh, we couldn't find what you looked for.</h2>
+        <h1>Hello world!</h1>
+        <h2>I'm gosoccerboy5.</h2>
         <br>
-        <a href="/">Return to the homepage?</a>
+        <a href="https://scratch.mit.edu/users/gosoccerboy5">My Scratch account</a>
         <br>
-        <a href="#" id="goback">Return back to where you were?</a>
-        <br>
-        <br>
-        <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"><span class="small">What's a 404 error?</span></a>
-        <script src="resources/index.js" onload="reference('/');"></script> 
-        <script>
-            document.querySelector("#goback").addEventListener("click", function(event) {
-                event.preventDefault();
-                history.go(-1);
-            });
-        </script>
+        <a href="https://github.com/gosoccerboy5/gosoccerboy5.github.io">The source for this project</a>
+        <br><br>
+        Feeling a bit lost? <a href="help/roadmap/">Here's a list of links</a>.
+        <script src="resources/index.js" onload="reference('./');"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,18 +1,28 @@
+
 <!DOCTYPE HTML>
-<!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/index.html -->
+<!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/404.html -->
+<!-- https://gosoccerboy5.github.io/404 -->
 <html>
     <head>
-        <title>My Github page</title>
+        <base href="https://gosoccerboy5.github.io" />
+        <title>404 - gosoccerboy5</title>
     </head>
     <body>
-        <h1>Hello world!</h1>
-        <h2>I'm gosoccerboy5.</h2>
+        <h1>404</h1>
+        <h2>Uh oh, we couldn't find what you looked for.</h2>
         <br>
-        <a href = "https://scratch.mit.edu/users/gosoccerboy5">My Scratch account</a>
+        <a href="/">Return to the homepage?</a>
         <br>
-        <a href = "https://github.com/gosoccerboy5/gosoccerboy5.github.io">The source for this project</a>
-        <br><br>
-        Feeling a bit lost? <a href = "help/roadmap/">Here's a list of links</a>.
-        <script src = "resources/index.js" onload="reference('./');"></script>
+        <a href="#" id="goback">Return back to where you were?</a>
+        <br>
+        <br>
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"><span class="small">What's a 404 error?</span></a>
+        <script src="resources/index.js" onload="reference('/');"></script> 
+        <script>
+            document.querySelector("#goback").addEventListener("click", function(event) {
+                event.preventDefault();
+                history.go(-1);
+            });
+        </script>
     </body>
 </html>

--- a/rickroll/index.html
+++ b/rickroll/index.html
@@ -1,3 +1,4 @@
+
 <!-- https://gosoccerboy5.github.io/rickroll/rickroll -->
 <!-- https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/rickroll/rickroll.html -->
 <!DOCTYPE HTML>
@@ -11,13 +12,13 @@
         This code allows you to rickroll people with HTML, but in a super-secret unsuspecting way.<br>
         To use it, just copy this script tag (you can click on it to select it).
         <br>
-        <textarea id = "code" readonly = "true">&lt;script src = "https://gosoccerboy5.github.io/rickroll/rickroll.js"&gt;&lt;/script&gt;</textarea>
+        <textarea id="code" readonly="true">&lt;script src="https://gosoccerboy5.github.io/rickroll/rickroll.js"&gt;&lt;/script&gt;</textarea>
         <br>
-        Then, just add 'class = "rickroll"' to any link you want to be a rickroll.
+        Then, just add 'class="rickroll"' to any link you want to be a rickroll.
         <br>
-        <a href = "https://scratch.mit.edu" class = "rickroll" title = "Note how the link apparently directs to Scratch.">Demo</a>
-        <script src = "../resources/index.js" onload="reference('../');"></script>
-        <script src = "rickroll.js"></script>
+        <a href="https://scratch.mit.edu" class="rickroll" title="Note how the link apparently directs to Scratch.">Demo</a>
+        <script src="../resources/index.js" onload="reference('../');"></script>
+        <script src="rickroll.js"></script>
         <script>
             document.querySelector("#code").addEventListener("click", function(event) {
                 document.querySelector("#code").select();

--- a/test/angry-emails.html
+++ b/test/angry-emails.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE HTML>
 <html>
     <head>
@@ -24,7 +25,7 @@ textarea {
     </head>
     <body>
         <h1>Make and send angry emails</h1>
-        <h2 title = "No, seriously. 
+        <h2 title="No, seriously. 
 Nothing is stored, so say whatever you want.">Type whatever you like!</h2>
         Dear 
         <input id="sendee" placeholder="whomever">,
@@ -41,7 +42,7 @@ Nothing is stored, so say whatever you want.">Type whatever you like!</h2>
         <button id="sendit">Send email!</button>
         <div id="emailsent" style="display: none;">Email sent successfully!</div>
         <small>Note: This is a joke. It doesn't actually send an email.</small>
-        <script src = "../resources/index.js" onload="reference('../');"></script>
+        <script src="../resources/index.js" onload="reference('../');"></script>
         <script>
             let fakeResponses = null;
             fetch("/test/email-responses.json").then(function(result) {

--- a/test/javascript-ide.html
+++ b/test/javascript-ide.html
@@ -62,6 +62,6 @@
                 }
             });
         </script> -->
-        <script src = "../resources/index.js" onload="reference('../');"></script>
+        <script src="../resources/index.js" onload="reference('../');"></script>
     </body>
 </html>

--- a/test/jokes.html
+++ b/test/jokes.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE HTML>
 <!--https://github.com/gosoccerboy5/gosoccerboy5.github.io/blob/main/test/jokes.html-->
 <!--https://gosoccerboy5.github.io/test/jokes.html-->
@@ -23,13 +24,13 @@
     </head>
     <body>
         <br>
-        <button id = "tellJoke">Tell me a joke!</button>
+        <button id="tellJoke">Tell me a joke!</button>
         <br><br>
-        <div id = "spinner"></div>
+        <div id="spinner"></div>
         <br>
         <br>
-        <span class = "small" title = "Beware, many of the jokes are computer/programming-themed">Credit to <a href = "https://github.com/jeffalo/my-ocular/blob/master/jokes.json">https://github.com/jeffalo/my-ocular/blob/master/jokes.json</a> for the jokes</span>
-        <script src = "../resources/index.js" onload="reference('../');"></script>
+        <span class="small" title="Beware, many of the jokes are computer/programming-themed">Credit to <a href="https://github.com/jeffalo/my-ocular/blob/master/jokes.json">https://github.com/jeffalo/my-ocular/blob/master/jokes.json</a> for the jokes</span>
+        <script src="../resources/index.js" onload="reference('../');"></script>
         <script>
             let jokes = null;
             let isLoading = false;


### PR DESCRIPTION
remove the spaces between attributes/equal signs, like
&lt;img src = "foo.png">
to
\<img src="foo.png">
to improve readability and consistency

### What issue does this solve?
_Please type which issues this will resolve. (eg: Resolves #100)_  
none lol
  
### What does this change?
_Please type what has been changed in this pull request, and how it resolves any problems.  
Be sure to provide screenshots of before/after if possible._  
idk just look at the git file changes
  
### Does it work?
_Please type if this works, where you have tested it, what issues pop up, and your specs. Again, also try to give any screenshots._
idek but if it doesn't I can revert the merge
